### PR TITLE
Implemented explicit cluster volumes

### DIFF
--- a/src/cluster.f90
+++ b/src/cluster.f90
@@ -172,6 +172,13 @@ module cluster
                     call pmk_missing_key_error("sigma", c%label)
                 end if
     
+                ! Get the cluster volume.
+                p => cfg%get_record(c%label, "volume")
+                if (associated(p)) then
+                    call process_volume_record(c, p%nr_args, p%args)
+                else
+                    c%volume = -1.0_dp
+                end if
             end do
     
             ! Set up the monomer array, assuming that everything is alright. We will check
@@ -187,9 +194,10 @@ module cluster
             end do
     
             ! Calculate cluster volumes, assuming that everything is alright. We will
-            ! check for errors later.
+            ! check for errors later. Consider only clusters for which no volume was
+            ! specified in the clusterset.
             do i = 1, nr_clusters
-                if (clusterset(i)%monomer) cycle
+                if (clusterset(i)%monomer .or. clusterset(i)%volume > 0.0_dp) cycle
                 clusterset(i)%volume = 0.0_dp
                 do j = 1, pmk_input%components
                     clusterset(i)%volume = clusterset(i)%volume + &

--- a/src/shared_data.f90
+++ b/src/shared_data.f90
@@ -34,7 +34,7 @@ module shared_data
     type :: global_data_t
         integer :: qce_iterations, newton_iterations, grid_iterations, optimizer, nconverged
         integer, dimension(:), allocatable :: degree
-        real(dp) :: press, mtot, vexcl
+        real(dp) :: press, mtot
         real(dp), dimension(:), allocatable :: ntot
         real(dp) :: max_deviation, vdamp, rotor_cutoff
         type(range_t) :: amf, bxv, temp

--- a/src/thermo.f90
+++ b/src/thermo.f90
@@ -198,8 +198,7 @@ module thermo
         ! Writes volume, exclusion volume and status code to file.
         subroutine write_volume(ntemp, converged, temp, vol, vexcl, alpha, solution)
             integer, intent(in) :: ntemp
-            real(dp), dimension(ntemp), intent(in) :: temp, vol, alpha
-            real(dp), intent(in) :: vexcl
+            real(dp), dimension(ntemp), intent(in) :: temp, vexcl, vol, alpha
             integer, dimension(ntemp), intent(in) :: solution
             logical, dimension(ntemp), intent(in) :: converged
 
@@ -220,7 +219,7 @@ module thermo
                     write(myunit, '(4(ES13.6,1X),I35)') &
                         temp(itemp), &
                         1.0e3_dp*vol(itemp), &
-                        1.0e3_dp*vexcl, &
+                        1.0e3_dp*vexcl(itemp), &
                         alpha(itemp), &
                         solution(itemp)
                 end if
@@ -477,8 +476,8 @@ module thermo
             use input, only: pmk_input
             integer, intent(in) :: ntemp, nclust
             real(dp), dimension(ntemp, nclust), intent(in) :: pop
-            real(dp), intent(in) :: press, vexcl
-            real(dp), dimension(ntemp), intent(in) :: temp, vol, dvol
+            real(dp), intent(in) :: press
+            real(dp), dimension(ntemp), intent(in) :: temp, vexcl, vol, dvol
             type(pf_t), dimension(ntemp, nclust), intent(in) :: lnq_clust, dlnq_clust, &
                 ddlnq_clust
             integer, dimension(ntemp), intent(in) :: solution


### PR DESCRIPTION
Peacemaker now allows the user to specify individual cluster volumes in the cluster set file. If no volume is specified, the cluster volume will be calculated from the monomer volumes as before. The exclusion volume is therefore not treated as a constant anymore and is not part of global_data anymore. Instead it is calculated for each temperature. If no cluster volumes are specified in the cluster set, the results should be equal to previous Peacemaker versions.